### PR TITLE
ensure priv directory exists prior to trying to write expand.so to it

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,6 +5,7 @@ defmodule Mix.Tasks.Compile.Libpostal do
       IO.warn("Windows is not supported.")
       exit(1)
     else
+      {_result, _error_code} = System.cmd("mkdir", ["-p", "priv"], stderr_to_stdout: true)
       {result, _error_code} = System.cmd("make", ["priv/parser.so"], stderr_to_stdout: true)
       IO.binwrite result
       {result, _error_code} = System.cmd("make", ["priv/expand.so"], stderr_to_stdout: true)


### PR DESCRIPTION
I hit a problem with compilation where the priv directory didn't exist.  I assume something about the packaging process on hex removed it, even though it's clear you were trying to ensure it's existence.  This seemed to fix the problem for me.

thanks!  This is cool stuff!