### PR TITLE
Fix Race Condition on Compilation

### DIFF
--- a/lib/expand.ex
+++ b/lib/expand.ex
@@ -3,6 +3,7 @@ defmodule Expostal.Expand do
   Address expansion module for Openvenue's Libpostal, which does expands addresses.
   """
 
+  @compile { :autoload, false }
   @on_load { :init, 0 }
 
   app = Mix.Project.config[:app]

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -3,6 +3,7 @@ defmodule Expostal.Parser do
   Address parsing module for Openvenue's Libpostal, which does parses addresses.
   """
 
+  @compile { :autoload, false }
   @on_load { :init, 0 }
 
   app = Mix.Project.config[:app]


### PR DESCRIPTION
This change solved the issue for me. It seems like it's a race condition on the build process of the dependency that causes it to try and load the .so file before it has been symlinked into the _build folder structure.

I used the ex_ncurses NIF as a reference here: https://github.com/jfreeze/ex_ncurses/blob/master/lib/ex_ncurses.ex#L2

Targets Issue #3 