### PR TITLE
Fix Dialyzer errors

### DIFF
--- a/lib/expand.ex
+++ b/lib/expand.ex
@@ -22,10 +22,12 @@ defmodule Expostal.Expand do
      "781 franklin avenue crown heights brooklyn ny"]
 
   """
-  @spec expand_address(address :: String.t) :: list(String.t)
-  def expand_address(address)
-  def expand_address(_) do
-    exit(:nif_library_not_loaded)
+  @spec expand_address(address :: String.t) :: [String.t]
+  def expand_address(address) do
+    case :erlang.phash2(1, 1) do
+      0 -> raise "Nif not loaded"
+      1 -> [address]
+    end
   end
 
 end

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -23,10 +23,13 @@ defmodule Expostal.Parser do
         road: "rene levesque ouest", state: "qc"}
 
   """
-  @spec parse_address(address :: String.t) :: String.t
+  @spec parse_address(address :: String.t) :: map
   def parse_address(address)
   def parse_address(_) do
-    exit(:nif_library_not_loaded)
+    case :erlang.phash2(1, 1) do
+      0 -> raise "Nif not loaded"
+      1 -> %{}
+    end
   end
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,10 @@ defmodule Expostal.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:ex_doc, "~> 0.14", only: :dev, runtime: false}]
+    [
+      {:ex_doc, "~> 0.14", only: :dev, runtime: false},
+      {:dialyxir, "~> 0.5", only: :dev, runtime: false}
+    ]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,4 @@
-%{"earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
+%{"dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "libpostal": {:git, "https://github.com/openvenues/libpostal.git", "8dd84b71bad4c70150e60c7bda8071b9bd8902f8", []}}


### PR DESCRIPTION
Anyone who uses expostal along with Dialyzer will have unsolvable type-spec errors right now because Dialyzer can't peer into the NIF to see what the actual return will be - it will assume that the functions parse_address() and expand_address() only call exit() - and as a result it is a no_return instead of whatever is written into the typespec.

This PR uses a workaround to still raise the error when the NIF isn't loaded, but to let Dialyzer know what the actual returns can be. It also fixes the typespec for parse_address to indicate that it actually returns a map, not a string.