### PR TITLE
fix: force linking of shared libraries during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 MIX = mix
-CFLAGS += -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter
+CFLAGS += -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter -Wl,--no-as-needed
 
 ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
 CFLAGS += -I$(ERLANG_PATH)
-CFLAGS += -I/usr/local/include -I/usr/include -L/usr/local/lib -L/usr/lib
-CFLAGS += -lpostal
+CFLAGS += $(shell pkg-config --cflags libpostal)
 CFLAGS += -std=gnu99 -Wno-unused-function
+
+LDFLAGS=$(shell pkg-config --libs libpostal)
 
 ifeq ($(wildcard deps/libpostal),)
 	LIBPOSTAL_PATH = ../libpostal


### PR DESCRIPTION
Force linking of shared libraries (libpostal) at build time instead of at runtime.

This fixes the issue of the built library (expostal.so) being unable to lookup symbols from libpostal at runtime on some systems.

```
expostal.so: undefined symbol: libpostal_expand_address
```